### PR TITLE
Modified code follow these review comments

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -91,17 +91,6 @@ if (BUILD_POSITION_INDEPENDENT_LIB)
   set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 endif ()
 
-if(NOT DEFINED ORC_SIMD_LEVEL)
-  set(ORC_SIMD_LEVEL
-      "DEFAULT"
-      CACHE STRING "Compile time SIMD optimization level")
-endif()
-if(NOT DEFINED ORC_RUNTIME_SIMD_LEVEL)
-  set(ORC_RUNTIME_SIMD_LEVEL
-      "MAX"
-      CACHE STRING "Max runtime SIMD optimization level")
-endif()
-
 #
 # Compiler specific flags
 #
@@ -172,102 +161,6 @@ elseif (MSVC)
   set (WARN_FLAGS "${WARN_FLAGS} -wd4146") # unary minus operator applied to unsigned type, result still unsigned
 endif ()
 
-include(CheckCXXCompilerFlag)
-include(CheckCXXSourceCompiles)
-message(STATUS "System processor: ${CMAKE_SYSTEM_PROCESSOR}")
-
-if(NOT DEFINED ORC_CPU_FLAG)
-  if(CMAKE_SYSTEM_PROCESSOR MATCHES "AMD64|X86|x86|i[3456]86|x64")
-    set(ORC_CPU_FLAG "x86")
-  elseif(CMAKE_SYSTEM_PROCESSOR MATCHES "aarch64|ARM64|arm64")
-    set(ORC_CPU_FLAG "aarch64")
-  elseif(CMAKE_SYSTEM_PROCESSOR MATCHES "^arm$|armv[4-7]")
-    set(ORC_CPU_FLAG "aarch32")
-  else()
-    message(FATAL_ERROR "Unknown system processor")
-  endif()
-endif()
-
-# Check architecture specific compiler flags
-if(ORC_CPU_FLAG STREQUAL "x86")
-  # x86/amd64 compiler flags, msvc/gcc/clang
-  if(MSVC)
-    set(ORC_AVX512_FLAG "/arch:AVX512")
-    set(CXX_SUPPORTS_SSE4_2 TRUE)
-  else()
-    # skylake-avx512 consists of AVX512F,AVX512BW,AVX512VL,AVX512CD,AVX512DQ
-    set(ORC_AVX512_FLAG "-march=native -mbmi2")
-    set(ORC_AVX512_FLAG
-        "${ORC_AVX512_FLAG} -mavx512f -mavx512cd -mavx512vl -mavx512dq -mavx512bw -mavx512vbmi")
-  endif()
-  check_cxx_compiler_flag(${ORC_AVX512_FLAG} CXX_SUPPORTS_AVX512)
-  if(MINGW)
-    # https://gcc.gnu.org/bugzilla/show_bug.cgi?id=65782
-    message(STATUS "Disable AVX512 support on MINGW for now")
-  else()
-    # Check for AVX512 support in the compiler.
-    set(OLD_CMAKE_REQURED_FLAGS ${CMAKE_REQUIRED_FLAGS})
-    set(CMAKE_REQUIRED_FLAGS "${CMAKE_REQUIRED_FLAGS} ${ORC_AVX512_FLAG}")
-    check_cxx_source_compiles("
-      #ifdef _MSC_VER
-      #include <intrin.h>
-      #else
-      #include <immintrin.h>
-      #endif
-
-      int main() {
-        __m512i mask = _mm512_set1_epi32(0x1);
-        char out[32];
-        _mm512_storeu_si512(out, mask);
-        return 0;
-      }"
-      CXX_SUPPORTS_AVX512)
-    set(CMAKE_REQUIRED_FLAGS ${OLD_CMAKE_REQURED_FLAGS})
-  endif()
-
-  message(STATUS "BUILD_ENABLE_AVX512=${BUILD_ENABLE_AVX512}")
-  message(STATUS "CXX_SUPPORTS_AVX512=${CXX_SUPPORTS_AVX512}")
-  message(STATUS "ORC_RUNTIME_SIMD_LEVEL=${ORC_RUNTIME_SIMD_LEVEL}")
-  # Runtime SIMD level it can get from compiler and ORC_RUNTIME_SIMD_LEVEL
-  if(BUILD_ENABLE_AVX512 AND CXX_SUPPORTS_AVX512 AND ORC_RUNTIME_SIMD_LEVEL MATCHES "^(AVX512|MAX)$")
-    message(STATUS "Enable the AVX512 vector decode of bit-packing")
-    set(ORC_HAVE_RUNTIME_AVX512 ON)
-    set(ORC_SIMD_LEVEL "AVX512")
-    add_definitions(-DORC_HAVE_RUNTIME_AVX512)
-  else ()
-    set(ORC_HAVE_RUNTIME_AVX512 OFF)
-    message(STATUS "Disable the AVX512 vector decode of bit-packing")
-  endif()
-  if(ORC_SIMD_LEVEL STREQUAL "DEFAULT")
-    set(ORC_SIMD_LEVEL "NONE")
-  endif()
-elseif(ORC_CPU_FLAG STREQUAL "aarch64")
-  # Arm64 compiler flags, gcc/clang only
-  set(ORC_ARMV8_MARCH "armv8-a")
-  check_cxx_compiler_flag("-march=${ORC_ARMV8_MARCH}+sve" CXX_SUPPORTS_SVE)
-  if(ORC_SIMD_LEVEL STREQUAL "DEFAULT")
-    set(ORC_SIMD_LEVEL "NEON")
-  endif()
-endif()
-message(STATUS "ORC_HAVE_RUNTIME_AVX512=${ORC_HAVE_RUNTIME_AVX512}")
-message(STATUS "ORC_SIMD_LEVEL=${ORC_SIMD_LEVEL}")
-
-# Only enable additional instruction sets if they are supported
-if(ORC_CPU_FLAG STREQUAL "x86")
-  if(MINGW)
-    # Enable _xgetbv() intrinsic to query OS support for ZMM register saves
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -mxsave")
-  endif()
-  if(ORC_SIMD_LEVEL STREQUAL "AVX512")
-    if(NOT CXX_SUPPORTS_AVX512)
-      message(FATAL_ERROR "AVX512 required but compiler doesn't support it.")
-    endif()
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${ORC_AVX512_FLAG}")
-  elseif(NOT ORC_SIMD_LEVEL STREQUAL "NONE")
-    message(WARNING "ORC_SIMD_LEVEL=${ORC_SIMD_LEVEL} not supported by x86.")
-  endif()
-endif()
-
 if (BUILD_CPP_ENABLE_METRICS)
   message(STATUS "Enable the metrics collection")
   add_compile_definitions(ENABLE_METRICS=1)
@@ -280,6 +173,7 @@ enable_testing()
 
 INCLUDE(CheckSourceCompiles)
 INCLUDE(ThirdpartyToolchain)
+INCLUDE(ConfigSimdLevel)
 
 set (EXAMPLE_DIRECTORY ${CMAKE_SOURCE_DIR}/examples)
 

--- a/c++/src/BitUnpackerAvx512.hh
+++ b/c++/src/BitUnpackerAvx512.hh
@@ -16,8 +16,10 @@
  * limitations under the License.
  */
 
-#ifndef VECTOR_DECODER_HH
-#define VECTOR_DECODER_HH
+#ifndef BIT_UNPACKER_AVX512_HH
+#define BIT_UNPACKER_AVX512_HH
+
+#if defined(ORC_HAVE_RUNTIME_AVX512)
 
 // Mingw-w64 defines strcasecmp in string.h
 #if defined(_WIN32) && !defined(strcasecmp)
@@ -27,7 +29,6 @@
 #include <strings.h>
 #endif
 
-#if defined(ORC_HAVE_RUNTIME_AVX512)
 #include <immintrin.h>
 #include <vector>
 
@@ -484,5 +485,6 @@ namespace orc {
     return result;
   }
 }  // namespace orc
-#endif
+
+#endif  // #if defined(ORC_HAVE_RUNTIME_AVX512)
 #endif

--- a/c++/src/BitUnpackerAvx512.hh
+++ b/c++/src/BitUnpackerAvx512.hh
@@ -16,8 +16,8 @@
  * limitations under the License.
  */
 
-#ifndef BIT_UNPACKER_AVX512_HH
-#define BIT_UNPACKER_AVX512_HH
+#ifndef ORC_BIT_UNPACKER_AVX512_HH
+#define ORC_BIT_UNPACKER_AVX512_HH
 
 #if defined(ORC_HAVE_RUNTIME_AVX512)
 

--- a/c++/src/Bpacking.cc
+++ b/c++/src/Bpacking.cc
@@ -17,7 +17,11 @@
  */
 
 #include "Bpacking.hh"
+#include "BpackingDefault.hh"
 #include "CpuInfoUtil.hh"
+#if defined(ORC_HAVE_RUNTIME_AVX512)
+#include "BpackingAvx512.hh"
+#endif
 
 namespace orc {
   int readLongsDefault(RleDecoderV2* decoder, int64_t* data, uint64_t offset, uint64_t len,
@@ -65,8 +69,8 @@ namespace orc {
     UnpackAvx512 unpackAvx512(decoder);
     UnpackDefault unpackDefault(decoder);
     uint64_t startBit = 0;
-    static const auto cpu_info = orc::CpuInfo::GetInstance();
-    if (cpu_info->IsSupported(CpuInfo::AVX512)) {
+    static const auto cpu_info = CpuInfo::getInstance();
+    if (cpu_info->isSupported(CpuInfo::AVX512)) {
       switch (fbs) {
         case 1:
           unpackAvx512.vectorUnpack1(data, offset, len);

--- a/c++/src/Bpacking.hh
+++ b/c++/src/Bpacking.hh
@@ -21,10 +21,7 @@
 
 #include <stdint.h>
 
-#include "BpackingDefault.hh"
-#if defined(ORC_HAVE_RUNTIME_AVX512)
-#include "BpackingAvx512.hh"
-#endif
+#include "RLEv2.hh"
 
 namespace orc {
   int readLongsDefault(RleDecoderV2* decoder, int64_t* data, uint64_t offset, uint64_t len,

--- a/c++/src/BpackingAvx512.cc
+++ b/c++/src/BpackingAvx512.cc
@@ -16,13 +16,13 @@
  * limitations under the License.
  */
 
+#if defined(ORC_HAVE_RUNTIME_AVX512)
+
 #include "BpackingAvx512.hh"
 #include "BitUnpackerAvx512.hh"
 #include "Utils.hh"
 
 namespace orc {
-
-#if defined(ORC_HAVE_RUNTIME_AVX512)
   UnpackAvx512::UnpackAvx512(RleDecoderV2* dec) : decoder(dec), unpackDefault(UnpackDefault(dec)) {
     // PASS
   }
@@ -4312,6 +4312,7 @@ namespace orc {
       startBit = decoder->bitsLeft == 0 ? 0 : (8 - decoder->bitsLeft);
     }
   }
-#endif
 
 }  // namespace orc
+
+#endif  // #if defined(ORC_HAVE_RUNTIME_AVX512)

--- a/c++/src/BpackingAvx512.hh
+++ b/c++/src/BpackingAvx512.hh
@@ -19,6 +19,8 @@
 #ifndef ORC_BPACKINGAVX512_HH
 #define ORC_BPACKINGAVX512_HH
 
+#if defined(ORC_HAVE_RUNTIME_AVX512)
+
 #include <stdint.h>
 #include <stdlib.h>
 
@@ -34,7 +36,6 @@ namespace orc {
 #define MAX_VECTOR_BUF_16BIT_LENGTH 32
 #define MAX_VECTOR_BUF_32BIT_LENGTH 16
 
-#if defined(ORC_HAVE_RUNTIME_AVX512)
   class UnpackAvx512 {
    public:
     UnpackAvx512(RleDecoderV2* dec);
@@ -82,8 +83,8 @@ namespace orc {
     // Used by vectorially 17~32 bit-unpacking data
     uint32_t vectorBuf32[MAX_VECTOR_BUF_32BIT_LENGTH + 1];
   };
-#endif
 
 }  // namespace orc
 
+#endif  // #if defined(ORC_HAVE_RUNTIME_AVX512)
 #endif

--- a/c++/src/CpuInfoUtil.cc
+++ b/c++/src/CpuInfoUtil.cc
@@ -27,6 +27,7 @@
 #endif
 
 #ifdef _WIN32
+#define NOMINMAX
 #include <Windows.h>
 #include <intrin.h>
 #endif
@@ -449,7 +450,7 @@ namespace orc {
 
     void ArchVerifyCpuRequirements(const CpuInfo* ci) {
 #if defined(ORC_HAVE_RUNTIME_AVX512)
-      if (!ci->IsDetected(CpuInfo::AVX512)) {
+      if (!ci->isDetected(CpuInfo::AVX512)) {
         throw ParseError("CPU does not support the Supplemental AVX512 instruction set");
       }
 #endif
@@ -466,7 +467,7 @@ namespace orc {
     }
 
     void ArchVerifyCpuRequirements(const CpuInfo* ci) {
-      if (!ci->IsDetected(CpuInfo::ASIMD)) {
+      if (!ci->isDetected(CpuInfo::ASIMD)) {
         throw ParseError("CPU does not support the Armv8 Neon instruction set");
       }
     }
@@ -504,7 +505,7 @@ namespace orc {
 
   CpuInfo::CpuInfo() : impl_(new Impl) {}
 
-  const CpuInfo* CpuInfo::GetInstance() {
+  const CpuInfo* CpuInfo::getInstance() {
     static CpuInfo cpu_info;
     return &cpu_info;
   }
@@ -525,7 +526,7 @@ namespace orc {
     return impl_->model_name;
   }
 
-  int64_t CpuInfo::CacheSize(CacheLevel level) const {
+  int64_t CpuInfo::cacheSize(CacheLevel level) const {
     constexpr int64_t kDefaultCacheSizes[] = {
         32 * 1024,    // Level 1: 32K
         256 * 1024,   // Level 2: 256K
@@ -541,15 +542,15 @@ namespace orc {
     return std::max(kDefaultCacheSizes[i], impl_->cache_sizes[i - 1]);
   }
 
-  bool CpuInfo::IsSupported(int64_t flags) const {
+  bool CpuInfo::isSupported(int64_t flags) const {
     return (impl_->hardware_flags & flags) == flags;
   }
 
-  bool CpuInfo::IsDetected(int64_t flags) const {
+  bool CpuInfo::isDetected(int64_t flags) const {
     return (impl_->original_hardware_flags & flags) == flags;
   }
 
-  void CpuInfo::VerifyCpuRequirements() const {
+  void CpuInfo::verifyCpuRequirements() const {
     return ArchVerifyCpuRequirements(this);
   }
 

--- a/c++/src/CpuInfoUtil.hh
+++ b/c++/src/CpuInfoUtil.hh
@@ -25,15 +25,17 @@
 
 namespace orc {
 
-  /// CpuInfo is an interface to query for cpu information at runtime.  The caller can
-  /// ask for the sizes of the caches and what hardware features are supported.
-  /// On Linux, this information is pulled from a couple of sys files (/proc/cpuinfo and
-  /// /sys/devices)
+  /**
+   * CpuInfo is an interface to query for cpu information at runtime.  The caller can
+   * ask for the sizes of the caches and what hardware features are supported.
+   * On Linux, this information is pulled from a couple of sys files (/proc/cpuinfo and
+   * /sys/devices)
+   */
   class CpuInfo {
    public:
     ~CpuInfo();
 
-    /// x86 features
+    // x86 features
     static constexpr int64_t SSSE3 = (1LL << 0);
     static constexpr int64_t SSE4_1 = (1LL << 1);
     static constexpr int64_t SSE4_2 = (1LL << 2);
@@ -49,53 +51,50 @@ namespace orc {
     static constexpr int64_t BMI1 = (1LL << 11);
     static constexpr int64_t BMI2 = (1LL << 12);
 
-    /// Arm features
+    // Arm features
     static constexpr int64_t ASIMD = (1LL << 32);
 
-    /// Cache enums for L1 (data), L2 and L3
+    // Cache enums for L1 (data), L2 and L3
     enum class CacheLevel { L1 = 0, L2, L3, Last = L3 };
 
-    /// CPU vendors
+    // CPU vendors
     enum class Vendor { Unknown, Intel, AMD };
 
-    static const CpuInfo* GetInstance();
+    static const CpuInfo* getInstance();
 
-    /// Returns all the flags for this cpu
+    // Returns all the flags for this cpu
     int64_t hardwareFlags() const;
 
-    /// Returns the number of cores (including hyper-threaded) on this machine.
+    // Returns the number of cores (including hyper-threaded) on this machine.
     int numCores() const;
 
-    /// Returns the vendor of the cpu.
+    // Returns the vendor of the cpu.
     Vendor vendor() const;
 
-    /// Returns the model name of the cpu (e.g. Intel i7-2600)
+    // Returns the model name of the cpu (e.g. Intel i7-2600)
     const std::string& modelName() const;
 
-    /// Returns the size of the cache in KB at this cache level
-    int64_t CacheSize(CacheLevel level) const;
+    // Returns the size of the cache in KB at this cache level
+    int64_t cacheSize(CacheLevel level) const;
 
-    /// \brief Returns whether or not the given feature is enabled.
-    ///
-    /// IsSupported() is true if IsDetected() is also true and the feature
-    /// wasn't disabled by the user (for example by setting the ORC_USER_SIMD_LEVEL
-    /// environment variable).
-    bool IsSupported(int64_t flags) const;
+    /**
+     * Returns whether or not the given feature is enabled.
+     * isSupported() is true if isDetected() is also true and the feature
+     * wasn't disabled by the user (for example by setting the ORC_USER_SIMD_LEVEL
+     * environment variable).
+     */
+    bool isSupported(int64_t flags) const;
 
-    /// Returns whether or not the given feature is available on the CPU.
-    bool IsDetected(int64_t flags) const;
+    // Returns whether or not the given feature is available on the CPU.
+    bool isDetected(int64_t flags) const;
 
-    /// Determine if the CPU meets the minimum CPU requirements and if not, issue an error
-    /// and terminate.
-    void VerifyCpuRequirements() const;
+    // Determine if the CPU meets the minimum CPU requirements and if not, issue an error
+    // and terminate.
+    void verifyCpuRequirements() const;
 
-    /// Toggle a hardware feature on and off.  It is not valid to turn on a feature
-    /// that the underlying hardware cannot support. This is useful for testing.
-    // void EnableFeature(int64_t flag, bool enable);
-
-    bool HasEfficientBmi2() const {
+    bool hasEfficientBmi2() const {
       // BMI2 (pext, pdep) is only efficient on Intel X86 processors.
-      return vendor() == Vendor::Intel && IsSupported(BMI2);
+      return vendor() == Vendor::Intel && isSupported(BMI2);
     }
 
    private:

--- a/c++/src/Dispatch.hh
+++ b/c++/src/Dispatch.hh
@@ -33,32 +33,32 @@ namespace orc {
     MAX
   };
 
-  /*
-    A facility for dynamic dispatch according to available DispatchLevel.
-
-    Typical use:
-
-      static void my_function_default(...);
-      static void my_function_avx512(...);
-
-      struct MyDynamicFunction {
-        using FunctionType = decltype(&my_function_default);
-
-        static std::vector<std::pair<DispatchLevel, FunctionType>> implementations() {
-          return {
-            { DispatchLevel::NONE, my_function_default }
-      #if defined(ARROW_HAVE_RUNTIME_AVX512)
-            , { DispatchLevel::AVX512, my_function_avx512 }
-      #endif
-          };
-        }
-      };
-
-      void my_function(...) {
-        static DynamicDispatch<MyDynamicFunction> dispatch;
-        return dispatch.func(...);
-      }
-  */
+  /**
+   * A facility for dynamic dispatch according to available DispatchLevel.
+   *
+   * Typical use:
+   *
+   *   static void my_function_default(...);
+   *   static void my_function_avx512(...);
+   *
+   *   struct MyDynamicFunction {
+   *     using FunctionType = decltype(&my_function_default);
+   *
+   *     static std::vector<std::pair<DispatchLevel, FunctionType>> implementations() {
+   *       return {
+   *         { DispatchLevel::NONE, my_function_default }
+   *   #if defined(ORC_HAVE_RUNTIME_AVX512)
+   *         , { DispatchLevel::AVX512, my_function_avx512 }
+   *   #endif
+   *       };
+   *     }
+   *   };
+   *
+   *   void my_function(...) {
+   *     static DynamicDispatch<MyDynamicFunction> dispatch;
+   *     return dispatch.func(...);
+   *   }
+   */
   template <typename DynamicFunction>
   class DynamicDispatch {
    protected:
@@ -92,13 +92,13 @@ namespace orc {
 
    private:
     bool IsSupported(DispatchLevel level) const {
-      static const auto cpu_info = orc::CpuInfo::GetInstance();
+      static const auto cpu_info = CpuInfo::getInstance();
 
       switch (level) {
         case DispatchLevel::NONE:
           return true;
         case DispatchLevel::AVX512:
-          return cpu_info->IsSupported(CpuInfo::AVX512);
+          return cpu_info->isSupported(CpuInfo::AVX512);
         default:
           return false;
       }

--- a/cmake_modules/ConfigSimdLevel.cmake
+++ b/cmake_modules/ConfigSimdLevel.cmake
@@ -1,0 +1,95 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+INCLUDE(CheckCXXCompilerFlag)
+message(STATUS "System processor: ${CMAKE_SYSTEM_PROCESSOR}")
+
+if(NOT DEFINED ORC_SIMD_LEVEL)
+  set(ORC_SIMD_LEVEL
+      "DEFAULT"
+      CACHE STRING "Compile time SIMD optimization level")
+endif()
+
+if(NOT DEFINED ORC_CPU_FLAG)
+  if(CMAKE_SYSTEM_PROCESSOR MATCHES "AMD64|X86|x86|i[3456]86|x64")
+    set(ORC_CPU_FLAG "x86")
+  elseif(CMAKE_SYSTEM_PROCESSOR MATCHES "^arm$|armv[4-7]")
+    set(ORC_CPU_FLAG "aarch32")
+  else()
+    message(STATUS "Unknown system processor")
+  endif()
+endif()
+
+# Check architecture specific compiler flags
+if(ORC_CPU_FLAG STREQUAL "x86")
+  # x86/amd64 compiler flags, msvc/gcc/clang
+  if(MSVC)
+    set(ORC_AVX512_FLAG "/arch:AVX512")
+  else()
+    # skylake-avx512 consists of AVX512F,AVX512BW,AVX512VL,AVX512CD,AVX512DQ
+    set(ORC_AVX512_FLAG "-march=native -mbmi2 -mavx512f -mavx512cd -mavx512vl -mavx512dq -mavx512bw -mavx512vbmi")
+  endif()
+  check_cxx_compiler_flag(${ORC_AVX512_FLAG} CXX_SUPPORTS_AVX512)
+  if(MINGW)
+    # https://gcc.gnu.org/bugzilla/show_bug.cgi?id=65782
+    message(STATUS "Disable AVX512 support on MINGW for now")
+  else()
+    # Check for AVX512 support in the compiler.
+    set(OLD_CMAKE_REQURED_FLAGS ${CMAKE_REQUIRED_FLAGS})
+    set(CMAKE_REQUIRED_FLAGS "${CMAKE_REQUIRED_FLAGS} ${ORC_AVX512_FLAG}")
+    check_cxx_source_compiles("
+      #ifdef _MSC_VER
+      #include <intrin.h>
+      #else
+      #include <immintrin.h>
+      #endif
+
+      int main() {
+        __m512i mask = _mm512_set1_epi32(0x1);
+        char out[32];
+        _mm512_storeu_si512(out, mask);
+        return 0;
+      }"
+      CXX_SUPPORTS_AVX512)
+    set(CMAKE_REQUIRED_FLAGS ${OLD_CMAKE_REQURED_FLAGS})
+  endif()
+
+  message(STATUS "BUILD_ENABLE_AVX512: ${BUILD_ENABLE_AVX512}")
+  # Runtime SIMD level it can get from compiler
+  if(BUILD_ENABLE_AVX512 AND CXX_SUPPORTS_AVX512)
+    message(STATUS "Enable the AVX512 vector decode of bit-packing, compiler support AVX512")
+    set(ORC_HAVE_RUNTIME_AVX512 ON)
+    set(ORC_SIMD_LEVEL "AVX512")
+    add_definitions(-DORC_HAVE_RUNTIME_AVX512)
+  elseif(BUILD_ENABLE_AVX512 AND NOT CXX_SUPPORTS_AVX512)
+    message(FATAL_ERROR "AVX512 required but compiler doesn't support it.")
+  elseif(NOT BUILD_ENABLE_AVX512)
+    set(ORC_HAVE_RUNTIME_AVX512 OFF)
+    message(STATUS "Disable the AVX512 vector decode of bit-packing")
+  endif()
+  if(ORC_SIMD_LEVEL STREQUAL "DEFAULT")
+    set(ORC_SIMD_LEVEL "NONE")
+  endif()
+
+  # Enable additional instruction sets if they are supported
+  if(MINGW)
+    # Enable _xgetbv() intrinsic to query OS support for ZMM register saves
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -mxsave")
+  endif()
+  if(ORC_SIMD_LEVEL STREQUAL "AVX512")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${ORC_AVX512_FLAG}")
+  elseif(NOT ORC_SIMD_LEVEL STREQUAL "NONE")
+    message(WARNING "ORC_SIMD_LEVEL=${ORC_SIMD_LEVEL} not supported by x86.")
+  endif()
+endif()
+
+message(STATUS "ORC_HAVE_RUNTIME_AVX512: ${ORC_HAVE_RUNTIME_AVX512}, ORC_SIMD_LEVEL: ${ORC_SIMD_LEVEL}")


### PR DESCRIPTION
1.Modified the CMakelists, delete the part of aarch64 and ORC_RUNTIME_SIMD_LEVEL, also changed the message content
2.Modified the print content and style about BUILD_ENABLE_AVX512, CXX_SUPPORTS_AVX512, ORC_HAVE_RUNTIME_AVX512 and ORC_SIMD_LEVEL
Delete the print of CXX_SUPPORTS_AVX512
3.Separate the configuration of AVX512 from CMakelists, and create a new cmake module "cmake_modules/ConfigSimdLevel.cmake" file
4.Modified the style of code comments
