### PR TITLE
Change RleDecoderV2::readLongs return type back to void.

### DIFF
--- a/c++/src/Bpacking.hh
+++ b/c++/src/Bpacking.hh
@@ -26,8 +26,8 @@ namespace orc {
 
   class BitUnpack {
    public:
-    static int readLongs(RleDecoderV2* decoder, int64_t* data, uint64_t offset, uint64_t len,
-                         uint64_t fbs);
+    static void readLongs(RleDecoderV2* decoder, int64_t* data, uint64_t offset, uint64_t len,
+                          uint64_t fbs);
   };
 }  // namespace orc
 

--- a/c++/src/BpackingAvx512.cc
+++ b/c++/src/BpackingAvx512.cc
@@ -4328,8 +4328,8 @@ namespace orc {
     }
   }
 
-  int BitUnpackAVX512::readLongs(RleDecoderV2* decoder, int64_t* data, uint64_t offset,
-                                 uint64_t len, uint64_t fbs) {
+  void BitUnpackAVX512::readLongs(RleDecoderV2* decoder, int64_t* data, uint64_t offset,
+                                  uint64_t len, uint64_t fbs) {
     UnpackAvx512 unpackAvx512(decoder);
     UnpackDefault unpackDefault(decoder);
     uint64_t startBit = 0;
@@ -4472,7 +4472,5 @@ namespace orc {
           break;
       }
     }
-
-    return 0;
   }
 }  // namespace orc

--- a/c++/src/BpackingAvx512.hh
+++ b/c++/src/BpackingAvx512.hh
@@ -78,8 +78,8 @@ namespace orc {
 
   class BitUnpackAVX512 : public BitUnpack {
    public:
-    static int readLongs(RleDecoderV2* decoder, int64_t* data, uint64_t offset, uint64_t len,
-                         uint64_t fbs);
+    static void readLongs(RleDecoderV2* decoder, int64_t* data, uint64_t offset, uint64_t len,
+                          uint64_t fbs);
   };
 
 }  // namespace orc

--- a/c++/src/BpackingDefault.cc
+++ b/c++/src/BpackingDefault.cc
@@ -327,8 +327,8 @@ namespace orc {
     }
   }
 
-  int BitUnpackDefault::readLongs(RleDecoderV2* decoder, int64_t* data, uint64_t offset,
-                                  uint64_t len, uint64_t fbs) {
+  void BitUnpackDefault::readLongs(RleDecoderV2* decoder, int64_t* data, uint64_t offset,
+                                   uint64_t len, uint64_t fbs) {
     UnpackDefault unpackDefault(decoder);
     switch (fbs) {
       case 4:
@@ -363,7 +363,6 @@ namespace orc {
         unpackDefault.plainUnpackLongs(data, offset, len, fbs);
         break;
     }
-    return 0;
   }
 
 }  // namespace orc

--- a/c++/src/BpackingDefault.hh
+++ b/c++/src/BpackingDefault.hh
@@ -50,8 +50,8 @@ namespace orc {
 
   class BitUnpackDefault : public BitUnpack {
    public:
-    static int readLongs(RleDecoderV2* decoder, int64_t* data, uint64_t offset, uint64_t len,
-                         uint64_t fbs);
+    static void readLongs(RleDecoderV2* decoder, int64_t* data, uint64_t offset, uint64_t len,
+                          uint64_t fbs);
   };
 
 }  // namespace orc

--- a/c++/src/RLEv2.hh
+++ b/c++/src/RLEv2.hh
@@ -206,7 +206,7 @@ namespace orc {
     int64_t readLongBE(uint64_t bsz);
     int64_t readVslong();
     uint64_t readVulong();
-    int readLongs(int64_t* data, uint64_t offset, uint64_t len, uint64_t fbs);
+    void readLongs(int64_t* data, uint64_t offset, uint64_t len, uint64_t fbs);
 
     template <typename T>
     uint64_t nextShortRepeats(T* data, uint64_t offset, uint64_t numValues, const char* notNull);

--- a/c++/src/RleDecoderV2.cc
+++ b/c++/src/RleDecoderV2.cc
@@ -84,7 +84,7 @@ namespace orc {
     }
   };
 
-  int RleDecoderV2::readLongs(int64_t* data, uint64_t offset, uint64_t len, uint64_t fbs) {
+  void RleDecoderV2::readLongs(int64_t* data, uint64_t offset, uint64_t len, uint64_t fbs) {
     static DynamicDispatch<UnpackDynamicFunction> dispatch;
     return dispatch.func(this, data, offset, len, fbs);
   }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. File a JIRA issue first and use it as a prefix of your PR title, e.g., `ORC-001: Fix ABC`.
  2. Use your PR title to summarize what this PR proposes instead of describing the problem.
  3. Make PR title and description complete because these will be the permanent commit log.
  4. If possible, provide a concise and reproducible example to reproduce the issue for a faster review.
  5. If the PR is unfinished, use GitHub PR Draft feature.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If there is a discussion in the mailing list, please add the link.
-->


### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->


### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
