### PR TITLE
Because check_cxx_source_run will be hung on windows, change check_cx…

### DIFF
--- a/cmake_modules/ConfigSimdLevel.cmake
+++ b/cmake_modules/ConfigSimdLevel.cmake
@@ -76,10 +76,13 @@ if(ORC_CPU_FLAG STREQUAL "x86")
                     COMMAND head -1
                     OUTPUT_VARIABLE flags_ver)
     message(STATUS "CPU ${flags_ver}")
+    execute_process(COMMAND grep avx512f /proc/cpuinfo
+                    COMMAND head -1
+                    OUTPUT_VARIABLE CPU_HAS_AVX512)
   endif()
 
   # Runtime SIMD level it can get from compiler
-  if(CXX_SUPPORTS_AVX512 AND COMPILER_SUPPORT_AVX512)
+  if(CPU_HAS_AVX512 AND CXX_SUPPORTS_AVX512 AND COMPILER_SUPPORT_AVX512)
     message(STATUS "Enabled the AVX512 for RLE bit-unpacking")
     set(ORC_SIMD_LEVEL "AVX512")
     add_definitions(-DORC_HAVE_RUNTIME_AVX512)

--- a/cmake_modules/ConfigSimdLevel.cmake
+++ b/cmake_modules/ConfigSimdLevel.cmake
@@ -54,7 +54,7 @@ if(ORC_CPU_FLAG STREQUAL "x86")
     # Check for AVX512 support in the compiler.
     set(OLD_CMAKE_REQURED_FLAGS ${CMAKE_REQUIRED_FLAGS})
     set(CMAKE_REQUIRED_FLAGS "${CMAKE_REQUIRED_FLAGS} ${ORC_AVX512_FLAG}")
-    check_cxx_source_runs("
+    CHECK_CXX_SOURCE_COMPILES("
       #ifdef _MSC_VER
       #include <intrin.h>
       #else


### PR DESCRIPTION
…x_source_run back CHECK_CXX_SOURCE_COMPILES, and added "grep avx512f /proc/cpuinfo" to check CPU flags.

<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. File a JIRA issue first and use it as a prefix of your PR title, e.g., `ORC-001: Fix ABC`.
  2. Use your PR title to summarize what this PR proposes instead of describing the problem.
  3. Make PR title and description complete because these will be the permanent commit log.
  4. If possible, provide a concise and reproducible example to reproduce the issue for a faster review.
  5. If the PR is unfinished, use GitHub PR Draft feature.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If there is a discussion in the mailing list, please add the link.
-->


### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->


### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
